### PR TITLE
Add academic panel page

### DIFF
--- a/_data/CONTRIBUTORS.yml
+++ b/_data/CONTRIBUTORS.yml
@@ -174,3 +174,30 @@ Kristina Gagalova:
 Jennifer Fleming:
     affiliation: Protein Data Bank in Europe (PDBe) European Bioinformatics Institute (EMBL-EBI)
     orcid: https://orcid.org/0000-0003-4016-8740
+
+Peter Czabotar:
+    affiliation: Walter and Eliza Hall Institute of Medical Research (WEHI)
+
+Matt Doyle:
+    affiliation: University of Sydney
+
+Bostjan Kobe:
+    affiliation: University of Queensland - IMB
+
+Emily Furlong:
+    affiliation: Australian National University
+
+Debnath Ghosal:
+    affiliation: Bio21 Institute of Molecular Science and Biotechnology (Bio21)
+
+Thomas Huber:
+    affiliation: Australian National University
+
+Mark Larance:
+    affiliation: University of Sydney
+
+Thomas Ve:
+    affiliation: Griffith University
+
+Nadia Zatsepin:
+    affiliation: Swinburne University of Technology

--- a/_data/CONTRIBUTORS.yml
+++ b/_data/CONTRIBUTORS.yml
@@ -177,27 +177,33 @@ Jennifer Fleming:
 
 Peter Czabotar:
     affiliation: Walter and Eliza Hall Institute of Medical Research (WEHI)
+    orcid: 0000-0002-2594-496X
 
 Matt Doyle:
     affiliation: University of Sydney
 
 Bostjan Kobe:
     affiliation: University of Queensland - IMB
+    orcid: 0000-0001-9413-9166
 
 Emily Furlong:
     affiliation: Australian National University
+    orcid: 0000-0002-9086-2979
 
 Debnath Ghosal:
     affiliation: Bio21 Institute of Molecular Science and Biotechnology (Bio21)
 
 Thomas Huber:
     affiliation: Australian National University
+    orcid: 0000-0002-3680-8699
 
 Mark Larance:
     affiliation: University of Sydney
+    orcid: 0000-0002-8579-2267
 
 Thomas Ve:
     affiliation: Griffith University
+    orcid: 0000-0002-0113-1905
 
 Nadia Zatsepin:
     affiliation: Swinburne University of Technology

--- a/_data/academic.yml
+++ b/_data/academic.yml
@@ -1,0 +1,59 @@
+intro: >
+  The Academic Advisory Panel brings together Australian researchers with expertise
+  in structural biology who generously volunteer their time to support and guide
+  the structural biology computing community. Meeting twice a year, the panel
+  provides expert advice, sector insight and a valuable connection to the needs
+  and priorities of researchers across Australia. Their contributions help ensure
+  the community remains informed, collaborative and responsive to developments in
+  structural biology and research computing.
+
+acknowledgement: >
+  We acknowledge the valuable contributions of past and present members of the
+  Academic Advisory Panel, including long-serving current members and those who
+  have completed their service.
+
+current_members:
+  - name: Charlie Bond
+    role: Prof
+  - name: Brett Collins
+    role: Prof
+  - name: Peter Czabotar
+    role: Prof
+  - name: Matt Doyle
+    role: Dr
+  - name: Rhys Grinter
+    role: Dr
+  - name: Johan Gustafsson
+    role: Dr
+  - name: Gavin Knott
+    role: Dr
+  - name: Bostjan Kobe
+    role: Prof
+  - name: Thomas Litfin
+    role: Dr
+  - name: Joel Mackay
+    role: Prof
+  - name: Katharine Michie
+    role: A/Prof
+  - name: Craig Morton
+    role: Dr
+  - name: Fiona Whelan
+    role: Dr
+
+former_members:
+  - name: Emily Furlong
+    role: Dr
+  - name: Debnath Ghosal
+    role: Dr
+  - name: Begoña Heras
+    role: Prof
+  - name: Thomas Huber
+    role: Prof
+  - name: Mark Larance
+    role: A/Prof
+  - name: Michael Parker
+    role: Prof
+  - name: Thomas Ve
+    role: A/Prof
+  - name: Nadia Zatsepin
+    role: A/Prof

--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -8,7 +8,11 @@ subitems:
   - title: Activities
     url: /activities
   - title: Contributors
-    url: /contributors
+    subitems:
+      - title: Academic Panel
+        url: /academic_panel
+      - title: Community Contributors
+        url: /community_contributors
   - title: Community library
     subitems:
       - title: General resources

--- a/_includes/academic-panel.html
+++ b/_includes/academic-panel.html
@@ -1,0 +1,101 @@
+{%- assign academic = site.data.academic %}
+
+{%- if academic.intro %}
+<p>{{ academic.intro }}</p>
+{%- endif %}
+
+{%- if academic.acknowledgement %}
+<p>{{ academic.acknowledgement }}</p>
+{%- endif %}
+
+{%- if academic.current_members %}
+<h2>Current 2026 Members</h2>
+<div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-xl-5 g-4 contributor-cards">
+{%- for contributor in academic.current_members %}
+  {%- assign contributor_name = contributor.name %}
+  {%- assign contributor_data = site.data.CONTRIBUTORS[contributor_name] %}
+  <div class="col">
+    <div class="card h-100">
+      {%- assign id = contributor_data.git | default: 'no_github' %}
+      <div class="position-relative">
+      {%- if contributor_data.image_url %}
+        <img src="{{ contributor_data.image_url }}" class="card-img-top p-3 rounded-circle" alt="{{ contributor_name }}">
+      {%- else %}
+        <img src="https://avatars.githubusercontent.com/{{ id }}" class="card-img-top p-3 rounded-circle" alt="{{ contributor_name }}">
+      {%- endif %}
+      {%- if contributor.role %}
+        <span class="badge position-absolute top-0 end-0">{{ contributor.role }}</span>
+      {%- endif %}
+      </div>
+      <div class="card-body text-center py-0">
+        <p class="card-title">{{ contributor_name }}</p>
+      {%- if contributor_data.affiliation %}
+        <p class="card-affiliation">{{ contributor_data.affiliation }}</p>
+      {%- endif %}
+      </div>
+      {%- if contributor_data.git or contributor_data.email or contributor_data.orcid %}
+        <div class="card-footer">
+          <div class="d-flex justify-content-center">
+          {%- if contributor_data.git %}
+            <div class="mx-1"><a class="btn bg-white text-primary hover-primary rounded-circle social-icons p-0" href="https://github.com/{{ id }}"><i class="fab fa-github"></i></a></div>
+          {%- endif %}
+          {%- if contributor_data.email %}
+            <div class="mx-1"><a class="btn bg-white text-primary hover-primary rounded-circle social-icons p-0" href="mailto:{{ contributor_data.email }}"><i class="fas fa-envelope"></i></a></div>
+          {%- endif %}
+          {%- if contributor_data.orcid %}
+            <div class="mx-1"><a class="btn bg-white text-primary hover-primary rounded-circle social-icons p-0" href="https://orcid.org/{{ contributor_data.orcid }}"><i class="fab fa-orcid"></i></a></div>
+          {%- endif %}
+          </div>
+        </div>
+      {%- endif %}
+    </div>
+  </div>
+{%- endfor %}
+</div>
+{%- endif %}
+
+{%- if academic.former_members %}
+<h2>Former Panel Members</h2>
+<div class="row row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-xl-5 g-4 contributor-cards">
+{%- for contributor in academic.former_members %}
+  {%- assign contributor_name = contributor.name %}
+  {%- assign contributor_data = site.data.CONTRIBUTORS[contributor_name] %}
+  <div class="col">
+    <div class="card h-100">
+      {%- assign id = contributor_data.git | default: 'no_github' %}
+      <div class="position-relative">
+      {%- if contributor_data.image_url %}
+        <img src="{{ contributor_data.image_url }}" class="card-img-top p-3 rounded-circle" alt="{{ contributor_name }}">
+      {%- else %}
+        <img src="https://avatars.githubusercontent.com/{{ id }}" class="card-img-top p-3 rounded-circle" alt="{{ contributor_name }}">
+      {%- endif %}
+      {%- if contributor.role %}
+        <span class="badge position-absolute top-0 end-0">{{ contributor.role }}</span>
+      {%- endif %}
+      </div>
+      <div class="card-body text-center py-0">
+        <p class="card-title">{{ contributor_name }}</p>
+      {%- if contributor_data.affiliation %}
+        <p class="card-affiliation">{{ contributor_data.affiliation }}</p>
+      {%- endif %}
+      </div>
+      {%- if contributor_data.git or contributor_data.email or contributor_data.orcid %}
+        <div class="card-footer">
+          <div class="d-flex justify-content-center">
+          {%- if contributor_data.git %}
+            <div class="mx-1"><a class="btn bg-white text-primary hover-primary rounded-circle social-icons p-0" href="https://github.com/{{ id }}"><i class="fab fa-github"></i></a></div>
+          {%- endif %}
+          {%- if contributor_data.email %}
+            <div class="mx-1"><a class="btn bg-white text-primary hover-primary rounded-circle social-icons p-0" href="mailto:{{ contributor_data.email }}"><i class="fas fa-envelope"></i></a></div>
+          {%- endif %}
+          {%- if contributor_data.orcid %}
+            <div class="mx-1"><a class="btn bg-white text-primary hover-primary rounded-circle social-icons p-0" href="https://orcid.org/{{ contributor_data.orcid }}"><i class="fab fa-orcid"></i></a></div>
+          {%- endif %}
+          </div>
+        </div>
+      {%- endif %}
+    </div>
+  </div>
+{%- endfor %}
+</div>
+{%- endif %}

--- a/_includes/academic-panel.html
+++ b/_includes/academic-panel.html
@@ -19,7 +19,7 @@
       {%- assign id = contributor_data.git | default: 'no_github' %}
       <div class="position-relative">
       {%- if contributor_data.image_url %}
-        <img src="{{ contributor_data.image_url }}" class="card-img-top p-3 rounded-circle" alt="{{ contributor_name }}">
+        <img src="{{ contributor_data.image_url | relative_url }}" class="card-img-top p-3 rounded-circle" alt="{{ contributor_name }}">
       {%- else %}
         <img src="https://avatars.githubusercontent.com/{{ id }}" class="card-img-top p-3 rounded-circle" alt="{{ contributor_name }}">
       {%- endif %}
@@ -65,7 +65,7 @@
       {%- assign id = contributor_data.git | default: 'no_github' %}
       <div class="position-relative">
       {%- if contributor_data.image_url %}
-        <img src="{{ contributor_data.image_url }}" class="card-img-top p-3 rounded-circle" alt="{{ contributor_name }}">
+        <img src="{{ contributor_data.image_url | relative_url }}" class="card-img-top p-3 rounded-circle" alt="{{ contributor_name }}">
       {%- else %}
         <img src="https://avatars.githubusercontent.com/{{ id }}" class="card-img-top p-3 rounded-circle" alt="{{ contributor_name }}">
       {%- endif %}

--- a/pages/academic_panel.md
+++ b/pages/academic_panel.md
@@ -1,0 +1,9 @@
+---
+title: Academic Panel
+page_id: academic_panel
+toc: false
+---
+
+The academic panel helps guide the community direction and roadmap.
+
+{% include academic-panel.html %}

--- a/pages/community_contributors.md
+++ b/pages/community_contributors.md
@@ -1,0 +1,9 @@
+---
+title: Community Contributors
+page_id: community_contributors
+toc: false
+---
+
+The projects included here represent a joint effort by the following people at multiple Australian institutions:
+
+{% include contributor-tiles-all.html %}

--- a/pages/contributors.md
+++ b/pages/contributors.md
@@ -1,13 +1,16 @@
 ---
-title: Community contributors
+title: Contributors
 page_id: contributors
 toc: false
-#type: resources
-toc: false
 redirect_from: /website/contributors/
+tiles:
+  - title: "Academic Panel"
+    url: /academic_panel
+  - title: "Community Contributors"
+    url: /community_contributors
 ---
 
-The projects included here represent a joint effort by the following people at multiple Australian institutions: 
+The Australian Structural Biology Computing website is supported by both an academic panel and a broader community of contributors.
 
 {% include contributor-tiles-all.html %}
 


### PR DESCRIPTION
This PR adds a page of Current and Former Academic Panel Members. Preview available at https://jscgh.github.io/website/academic_panel